### PR TITLE
Support for additional parameters

### DIFF
--- a/class.simple_mail.php
+++ b/class.simple_mail.php
@@ -43,6 +43,12 @@ class Simple_Mail
 	protected $_headers = array();
 	
 	/**
+	 * @var string $_additionalParameters (default value: NULL)
+	 * @access protected
+	 */
+	protected $_additionalParameters	= NULL;
+		
+	/**
 	 * @var boolean $_throwExceptions (default value: FALSE)
 	 * @access protected
 	 */
@@ -209,6 +215,23 @@ class Simple_Mail
 		$this->_headers[] = "$header: $value";
 		return $this;
 	}
+		
+	/**
+	 * setAdditionalParameters function.
+	 * 
+	 * @access public
+	 * @param	string		$additionalParameters
+	 * @return void
+	 */
+	public function setAdditionalParameters($additionalParameters)
+	{
+		if ( ! is_string($additionalParameters) && $this->_throwExceptions) {
+			throw new InvalidArgumentException();
+		}
+		
+		$this->_additionalParameters = $additionalParameters;
+		return $this;
+	}
 	
 	/**
 	 * setWrap function.
@@ -237,7 +260,7 @@ class Simple_Mail
 	{			
 		$headers = ( !empty($this->_headers) ) ? join("\r\n", $this->_headers) : array();
 		
-		$send = mail($this->_to, $this->_subject, wordwrap($this->_message, $this->_wrap), $headers);
+		$send = mail($this->_to, $this->_subject, wordwrap($this->_message, $this->_wrap), $headers, $this->_additionalParameters);
 		
 		if ( ! $send && $this->_throwExceptions) {
 			throw new Exception('Email failed to send');


### PR DESCRIPTION
The additional_parameters parameter can be used to pass additional flags as command line options to the program configured to be used when sending mail, as defined by the sendmail_path configuration setting. For example, this can be used to set the envelope sender address when using sendmail with the -f sendmail option.

cf http://php.net/manual/en/function.mail.php

Signed-off-by: Matthieu Baudoux matthieu@hypernovae.be
