### PR TITLE
Latin characters in the subject

### DIFF
--- a/class.simple_mail.php
+++ b/class.simple_mail.php
@@ -625,7 +625,7 @@ class Simple_Mail
 
         return strtr(
             filter_var(
-                $data, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH
+                $data, FILTER_SANITIZE_STRING
             ),
             $rule
         );


### PR DESCRIPTION
Ensure that latin characters, as cedilla, could be accepted in the
subject.

With FILTER_FLAG_STRIP_HIGH as was before, too many chars from latin was removed from string.
