### PR TITLE
Changed filterOther() method to strip only control characters

### DIFF
--- a/class.simple_mail.php
+++ b/class.simple_mail.php
@@ -567,8 +567,8 @@ class SimpleMail
     /**
      * filterOther
      *
-     * Removes any carriage return, line feed or tab characters before
-     * sanitizing.
+     * Removes ASCII control characters including any carriage return, line
+     * feed or tab characters.
      *
      * @param string $data The data to filter.
      *
@@ -576,12 +576,7 @@ class SimpleMail
      */
     public function filterOther($data)
     {
-        $rule = array(
-            "\r" => '',
-            "\n" => '',
-            "\t" => ''
-        );
-        return strtr(filter_var($data, FILTER_SANITIZE_STRING), $rule);
+        return filter_var($data, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW);
     }
 
     /**

--- a/tests/class.simple_mail.test.php
+++ b/tests/class.simple_mail.test.php
@@ -238,6 +238,27 @@ class testSimpleMail extends PHPUnit_Framework_TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testFilterOtherLeavesQuotes()
+    {
+        $expected = 'Hello "World"';
+        $actual   = $this->mailer->filterOther($expected);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testFilterOtherLeavesTags()
+    {
+        $expected = 'Hello <World>';
+        $actual   = $this->mailer->filterOther($expected);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testFilterOtherLeavesHighAscii()
+    {
+        $expected = "Hej världen!";
+        $actual   = $this->mailer->filterOther($expected);
+        $this->assertSame($expected, $actual);
+    }
+
     public function testFilterEmailRemovesCarriageReturns()
     {
         $string = "test@test.com\r";


### PR DESCRIPTION
Originally filterOther() used FILTER_SANITIZE_STRING, which strips and
encodes characters that are perfectly valid in email subject lines.

Added tests to validate the change.