### PR TITLE
Added Quoted-Printable encoding for attachment message bodies.

### DIFF
--- a/class.simple_mail.php
+++ b/class.simple_mail.php
@@ -445,10 +445,10 @@ class SimpleMail
         $body = array();
         $body[] = "This is a multi-part message in MIME format.";
         $body[] = "--{$this->_uid}";
-        $body[] = "Content-type:text/html; charset=\"utf-8\"";
-        $body[] = "Content-Transfer-Encoding: 7bit";
+        $body[] = "Content-Type: text/html; charset=\"utf-8\"";
+        $body[] = "Content-Transfer-Encoding: quoted-printable";
         $body[] = "";
-        $body[] = $this->_message;
+        $body[] = quoted_printable_encode($this->_message);
         $body[] = "";
         $body[] = "--{$this->_uid}";
 

--- a/tests/class.simple_mail.test.php
+++ b/tests/class.simple_mail.test.php
@@ -525,6 +525,20 @@ class testSimpleMail extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $name);
     }
 
+    /**
+     * @test
+     */
+    public function it_qp_encodes_attachment_message_bodies()
+    {
+        $message = "J'interdis aux marchands de vanter trop leur marchandises. Car ils se font vite pédagogues et t'enseignent comme but ce qui n'est par essence qu'un moyen, et te trompant ainsi sur la route à suivre les voilà bientôt qui te dégradent, car si leur musique est vulgaire ils te fabriquent pour te la vendre une âme vulgaire.";
+
+        $this->mailer->setMessage($message)
+                     ->addAttachment($this->directory.'/example/pbXBsZSwgY2hh.jpg', 'lolcat_finally_arrived.jpg');
+
+        $body = $this->mailer->assembleAttachmentBody();
+        $this->assertRegExp('/^Content-Transfer-Encoding: quoted-printable$/m', $body);
+    }
+
     public function tearDown()
     {
         unset($this->mailer);


### PR DESCRIPTION
MailHog wouldn't display the HTML portion of messages that had attachments. Quoted printable encoding the HTML message bodies fixed the problem.